### PR TITLE
Add USB auto-mounting script under automation/  (#10)

### DIFF
--- a/automation/usb-mount.sh
+++ b/automation/usb-mount.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# ============================================================
+# 🔧 USB Auto-Mounter Script
+# Detects all connected USB drives (removable partitions)
+# Mounts them to /mnt/usb-<label or uuid>
+# ============================================================
+
+set -euo pipefail
+
+echo "🔍 Scanning for USB drives..."
+
+# Get list of removable partitions (RM=1, TYPE=part)
+usb_partitions=$(lsblk -rpno NAME,RM,TYPE | awk '$2=="1" && $3=="part" {print $1}')
+
+if [[ -z "$usb_partitions" ]]; then
+    echo "❌ No USB partitions detected."
+    exit 0
+fi
+
+for device in $usb_partitions; do
+    echo -e "\n📦 Found device: $device"
+
+    # Use blkid to get label and UUID
+    label=$(blkid -o value -s LABEL "$device" 2>/dev/null || true)
+    uuid=$(blkid -o value -s UUID "$device" 2>/dev/null || true)
+
+    # Fallback if label is missing
+    if [[ -z "$label" && -n "$uuid" ]]; then
+        label="usb-$uuid"
+        echo "⚠️ No label found — using UUID: $label"
+    elif [[ -z "$label" && -z "$uuid" ]]; then
+        echo "❌ Skipping $device — no label or UUID found."
+        continue
+    fi
+
+    # Sanitize label for folder names
+    safe_label=$(echo "$label" | tr -cd '[:alnum:]_-')
+    mount_point="/mnt/usb-$safe_label"
+
+    # Create mount point if it doesn't exist
+    if [[ ! -d "$mount_point" ]]; then
+        echo "📂 Creating mount point: $mount_point"
+        sudo mkdir -p "$mount_point"
+    fi
+
+    # Check if device is already mounted
+    if mount | grep -q "$mount_point"; then
+        echo "✅ Already mounted at $mount_point — skipping."
+        continue
+    fi
+
+    # Mount the device
+    echo "🔗 Mounting $device to $mount_point..."
+    if sudo mount "$device" "$mount_point"; then
+        echo "✅ Successfully mounted $device at $mount_point"
+    else
+        echo "❌ Failed to mount $device"
+    fi
+done
+
+echo -e "\n🎉 All USB drives processed.\n"


### PR DESCRIPTION
### 📌 Summary

This pull request introduces a Bash script that detects all connected USB drives and automatically mounts them to uniquely labeled directories under `/mnt/usb-<label>`. This feature is especially useful for **headless Linux environments** (e.g., servers, Raspberry Pi, or minimal distros) where GUI auto-mounting is not available.

---

### 📂 Changes Introduced

- ➕ Added: `automation/usb-mount.sh`  
  ↳ A fully self-contained and tested script to:
  - Detect removable USB partitions using `lsblk`
  - Extract `LABEL` or fallback to `UUID` using `blkid`
  - Create safe, consistent mount points in `/mnt/usb-<label>`
  - Skip already-mounted devices
  - Mount drives safely and cleanly

---

### 🧪 Testing

Tested on:
- ✅ Ubuntu Server 22.04 LTS (headless)
- ✅ Multiple USB drives (with and without labels)
- ✅ Re-entrant safety (script can be rerun with no side effects)
- ✅ Manual mount validation via `ls /mnt/usb-<label>`

---

### ⚙️ Tools Used

- `lsblk`, `blkid`, `mount`, `awk`, `mkdir`

---

### 📝 Usage

```bash
sudo bash automation/usb-mount.sh
```


Closes #10 