### PR TITLE
Added login-alert script

### DIFF
--- a/security/Readme.md
+++ b/security/Readme.md
@@ -116,3 +116,5 @@ security/folder-encryptor.sh
 ## ✍️ Author
 
 [Surge77](https://github.com/Surge77)  — Contributed for HashSlap Summer of Code (HSSoC)
+
+

--- a/security/login-alert.sh
+++ b/security/login-alert.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# login-alert.sh — Monitor for failed SSH login attempts
+# Watches /var/log/auth.log and logs suspicious login attempts
+# Optional: Uses notify-send for desktop alerts if available
+
+LOG_FILE="/var/log/auth.log"  # Change to /var/log/secure for RHEL/CentOS
+OUTPUT_LOG="$HOME/login_warnings.txt"
+
+echo "🔍 Monitoring SSH login attempts..."
+echo "Writing suspicious activity to $OUTPUT_LOG"
+
+# Ensure output log exists
+touch "$OUTPUT_LOG"
+
+# Function to send notification (if GUI/notify-send available)
+send_notification() {
+    local msg="$1"
+    if command -v notify-send &> /dev/null; then
+        notify-send "SSH Alert" "$msg"
+    fi
+    logger -p auth.warning "$msg"
+}
+
+# Monitor log file for failed SSH attempts
+tail -Fn0 "$LOG_FILE" | while read -r line; do
+    if echo "$line" | grep -qi "Failed password"; then
+        TIMESTAMP=$(echo "$line" | awk '{print $1, $2, $3}')
+        IP=$(echo "$line" | grep -oE 'from ([0-9]{1,3}\.){3}[0-9]{1,3}' | awk '{print $2}')
+        USER=$(echo "$line" | grep -oP "for (invalid user )?\K\S+")
+
+        MESSAGE="⚠️ Failed SSH login: user=$USER, ip=$IP, time=$TIMESTAMP"
+        echo "$MESSAGE" >> "$OUTPUT_LOG"
+        echo "$MESSAGE"
+
+        send_notification "$MESSAGE"
+    fi
+done


### PR DESCRIPTION
# 🚨 SSH Login Alert Script

A simple Bash script that monitors your system’s SSH log file in real-time to detect failed login attempts. It logs suspicious activity and optionally sends desktop notifications.

## Issue: #9 
---

## 📌 Features

- 🔍 Monitors `/var/log/auth.log` or `/var/log/secure`
- 🚫 Detects failed SSH login attempts (invalid users, wrong passwords)
- 📝 Logs suspicious attempts to `~/login_warnings.txt`
- 🖥️ Sends desktop notifications via `notify-send` (if available)
- 🧩 Uses standard Linux tools: `tail`, `grep`, `awk`, `logger`

---

## 🚀 Usage
1. Make the script executable

`chmod +x security/login-alert.sh`

2. Run the script in background

`./security/login-alert.sh `



